### PR TITLE
fix: Remove no-deps option from pip install to ensure dependencies are installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_CREATE=1 \
     POETRY_CACHE_DIR="/tmp/poetry_cache"
 RUN poetry install --no-root && rm -rf $POETRY_CACHE_DIR
-RUN /usr/local/.venv/bin/pip install --no-deps .
+RUN /usr/local/.venv/bin/pip install .
 
 # runtime image
 FROM python:3.11-slim AS runtime


### PR DESCRIPTION
**Problem**
Currently, the Dockerfile includes the command `pip install --no-deps .` which causes issues at runtime with the Docker container, notably the error `ModuleNotFoundError: No module named 'tensorflow'`. This problem arises because this command does not install the necessary dependencies alongside the project.

**Issue**
close #35

**Solution**
This pull request removes the `--no-deps` flag from the `pip install` command in the Dockerfile. This change ensures that all dependencies specified in `pyproject.toml` are correctly installed in the Docker environment, preventing runtime errors related to missing modules.