### PR TITLE
feat: Add multiple molecular property filters for molecule generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ ChemTSv2 provides:
 
 ### Requirements :memo:
 
->[!NOTE]
->ARM architecture, e.g., Apple Silicon, is not currently supported
-
 <details>
   <summary>Click to show/hide requirements</summary>
 

--- a/filter/hba_filter.py
+++ b/filter/hba_filter.py
@@ -1,0 +1,15 @@
+from rdkit.Chem import Descriptors
+
+from chemtsv2.filter import Filter
+from chemtsv2.utils import transform_linker_to_mol
+
+class HBAFilter(Filter):
+    def check(mol, config): 
+        return Descriptors.NumHAcceptors(mol) <= config['hba_filter']['threshold']
+    
+class HBAFilterForXMol(Filter):
+    def check(mol, conf):
+        @transform_linker_to_mol(conf)
+        def _check(mol, conf):
+            return HBAFilter.check(mol, conf)
+        return _check(mol, conf)

--- a/filter/logp_filter.py
+++ b/filter/logp_filter.py
@@ -1,0 +1,15 @@
+from rdkit.Chem import Descriptors
+
+from chemtsv2.filter import Filter
+from chemtsv2.utils import transform_linker_to_mol
+
+class LogPFilter(Filter):
+    def check(mol, config): 
+        return Descriptors.MolLogP(mol) <= config['logp_filter']['threshold']
+    
+class LogPFilterForXMol(Filter):
+    def check(mol, conf):
+        @transform_linker_to_mol(conf)
+        def _check(mol, conf):
+            return LogPFilter.check(mol, conf)
+        return _check(mol, conf)

--- a/filter/mw_filter.py
+++ b/filter/mw_filter.py
@@ -1,0 +1,15 @@
+from rdkit.Chem import Descriptors
+
+from chemtsv2.filter import Filter
+from chemtsv2.utils import transform_linker_to_mol
+
+class MWFilter(Filter):
+    def check(mol, config): 
+        return Descriptors.MolWt(mol) <= config['mw_filter']['threshold']
+    
+class MWFilterForXMol(Filter):
+    def check(mol, conf):
+        @transform_linker_to_mol(conf)
+        def _check(mol, conf):
+            return MWFilter.check(mol, conf)
+        return _check(mol, conf)

--- a/filter/nrotb_filter.py
+++ b/filter/nrotb_filter.py
@@ -1,0 +1,15 @@
+from rdkit.Chem import Descriptors
+
+from chemtsv2.filter import Filter
+from chemtsv2.utils import transform_linker_to_mol
+
+class NRotBFilter(Filter):
+    def check(mol, config): 
+        return Descriptors.NumRotatableBonds(mol) <= config['nrotb_filter']['threshold']
+    
+class NRotBFilterForXMol(Filter):
+    def check(mol, conf):
+        @transform_linker_to_mol(conf)
+        def _check(mol, conf):
+            return NRotBFilter.check(mol, conf)
+        return _check(mol, conf)

--- a/filter/tpsa_filter.py
+++ b/filter/tpsa_filter.py
@@ -1,0 +1,15 @@
+from rdkit.Chem import Descriptors
+
+from chemtsv2.filter import Filter
+from chemtsv2.utils import transform_linker_to_mol
+
+class TPSAFilter(Filter):
+    def check(mol, config): 
+        return Descriptors.TPSA(mol) <= config['tpsa_filter']['threshold']
+    
+class TPSAFilterForXMol(Filter):
+    def check(mol, conf):
+        @transform_linker_to_mol(conf)
+        def _check(mol, conf):
+            return TPSAFilter.check(mol, conf)
+        return _check(mol, conf)


### PR DESCRIPTION
This PR introduces multiple molecular property filters. The following filters have been added:

- Molecular weight filter (mw_filter.py)
- Rotatable bonds filter (nrotb_filter.py)
- Topological polar surface area (TPSA) filter (tpsa_filter.py)
- Hydrogen bond donor filter (hbd_filter.py)
- Hydrogen bond acceptor filter (hba_filter.py)
- LogP filter (logp_filter.py)

These filters can also be used for linker generation.